### PR TITLE
xpcfg Usage

### DIFF
--- a/CMakePresetsBase.json
+++ b/CMakePresetsBase.json
@@ -6,6 +6,7 @@
       "hidden": true,
       "binaryDir": "${sourceDir}/_bld-${presetName}",
       "cacheVariables": {
+        "VERBOSE_DEFS_OPTS": "ON",
         "CMAKE_EXPERIMENTAL_GENERATE_SBOM": "ca494ed3-b261-4205-a01f-603c95e4cae0"
       }
     }


### PR DESCRIPTION
see issue https://github.com/externpro/externpro/issues/189 description

>it would be great to update libsodium [configure.cmake](https://github.com/externpro/libsodium/blob/xpv1.0.22.1/configure.cmake) to leverage externpro's [xpcfg.cmake](https://github.com/externpro/externpro/blob/main/cmake/xpcfg.cmake) similar to how other `[auto]` modified externpro projects have done
